### PR TITLE
Fix PHP 8+ deprecation warnings breaking JSON parsing

### DIFF
--- a/packages/language-server/src/phpInterop/PhpExecutor.ts
+++ b/packages/language-server/src/phpInterop/PhpExecutor.ts
@@ -19,6 +19,8 @@ export class PhpExecutor implements IPhpExecutor {
         }
 
         const result = await exec(this._phpExecutable, [
+            '-d',
+            'display_errors=stderr',
             command,
             ...args,
         ], {


### PR DESCRIPTION
## Summary

- Pass `-d display_errors=stderr` to PHP executable when invoking commands
- This redirects deprecation warnings to stderr, keeping stdout clean for JSON output

## Problem

Since PHP 8.0, the default `error_reporting` includes `E_DEPRECATED`, causing deprecation notices to be output to stdout. This pollutes the JSON output from commands like `bin/console debug:twig --format json`, breaking the language server's JSON parsing.

Fixes #69

## Approach

As suggested by @moetelo in #71, this uses PHP's `-d` flag to set `display_errors=stderr` at runtime. This ensures errors are redirected before any PHP code executes, making it effective even when deprecations occur in early bootstrap code (e.g., before Craft CMS can suppress them).

This approach is preferable to stripping text before JSON (as proposed in #71) because:
1. It's more robust - no risk of deprecation messages containing `{` or `[` characters
2. It works at the PHP runtime level, before any application code runs
3. The language server controls its own PHP invocation, so it's not affected by user environment constraints (DDEV/Docker)

## Test plan

- [x] Test with PHP 8.4 and a project that triggers deprecation warnings
- [x] Verify JSON parsing works correctly with deprecations present