### PR TITLE
Use HaaLeo/publish-vscode-extension for VS Code and Open VSX publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 env:
   NPM_TOKEN: ${{ secrets.NPM_PAT }}
   VSCE_PAT: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+  OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
 
 jobs:
   deploy:
@@ -22,7 +23,6 @@ jobs:
           run_install: |
             - recursive: true
               args: [--frozen-lockfile, --strict-peer-dependencies]
-            - args: [--global, "@vscode/vsce"]
 
       - uses: actions/setup-node@v4
         with:
@@ -31,8 +31,21 @@ jobs:
 
       - run: pnpm build
 
-      - run: vsce publish --no-dependencies
-        working-directory: ./packages/vscode
+      - name: Publish to VS Code Marketplace
+        if: ${{ env.VSCE_PAT != '' }}
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          packagePath: ./packages/vscode
+          dependencies: false
+
+      - name: Publish to Open VSX
+        if: ${{ env.OPEN_VSX_TOKEN != '' }}
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          registryUrl: https://open-vsx.org
+          packagePath: ./packages/vscode
 
       - name: pnpm publish
         working-directory: ./packages/language-server


### PR DESCRIPTION
## Summary

- Switch from direct `vsce` CLI to `HaaLeo/publish-vscode-extension` action
- Add support for publishing to Open VSX registry
- Add conditional publishing based on token availability

Closes #61

## Migration Guide

### New Secret Required

To enable publishing to Open VSX registry, add the following secret to your repository:

| Secret Name | Description |
|-------------|-------------|
| `OPEN_VSX_TOKEN` | Personal Access Token from [Open VSX](https://open-vsx.org/) |

### How to get an Open VSX token

1. Go to https://open-vsx.org/
2. Sign in with your GitHub account
3. Go to Settings → Access Tokens
4. Create a new token with publish permissions

### Existing Secrets

The existing `VS_MARKETPLACE_TOKEN` secret is still used for VS Code Marketplace publishing (no changes required).

### Conditional Publishing

Both publishing steps are conditional:
- If `OPEN_VSX_TOKEN` is not set, Open VSX publishing is skipped
- If `VS_MARKETPLACE_TOKEN` is not set, VS Code Marketplace publishing is skipped

This allows gradual adoption without breaking existing workflows.