### PR TITLE
fix: use LSP-compliant dynamic file watcher registration

### DIFF
--- a/packages/language-server/src/documents/DocumentCache.ts
+++ b/packages/language-server/src/documents/DocumentCache.ts
@@ -111,4 +111,16 @@ export class DocumentCache {
         this.documents.set(documentUri, document);
         return document;
     }
+
+    remove(documentUri: DocumentUri) {
+        this.documents.delete(toDocumentUri(documentUri));
+    }
+
+    async refresh(documentUri: DocumentUri) {
+        const normalizedUri = toDocumentUri(documentUri);
+        const document = this.documents.get(normalizedUri);
+        if (document) {
+            await this.setText(document);
+        }
+    }
 }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -3,7 +3,6 @@ import {
     ExtensionContext,
     window,
     WorkspaceFolder,
-    RelativePattern,
     commands,
     CompletionList,
     Uri,
@@ -46,11 +45,6 @@ async function addWorkspaceFolder(
     context: ExtensionContext
 ): Promise<void> {
     const folderPath = workspaceFolder.uri.fsPath;
-    const fileEvents = workspace.createFileSystemWatcher(
-        new RelativePattern(workspaceFolder, '*.twig'),
-    );
-
-    context.subscriptions.push(fileEvents);
 
     if (clients.has(folderPath)) {
         return;
@@ -89,9 +83,6 @@ async function addWorkspaceFolder(
                 pattern: `${folderPath}/**`,
             },
         ],
-        synchronize: {
-            fileEvents,
-        },
         middleware: {
             async provideCompletionItem(
                 document,


### PR DESCRIPTION
## Summary
- Moves file watching from client-side (VSCode-specific) to server-side using the LSP standard `client/registerCapability` request
- Removes client-side `FileSystemWatcher` from `extension.ts`
- Adds dynamic registration for `didChangeWatchedFiles` in `onInitialized`
- Handles file changes via `connection.onDidChangeWatchedFiles`
- Adds `remove()` and `refresh()` methods to `DocumentCache`

## Benefits
- **LSP-compliant**: Follows LSP 3.17 specification
- **Editor-agnostic**: Works with any LSP-compliant editor (Neovim, Sublime, Emacs, etc.)
- **Flexible patterns**: Server controls which files to watch

## Test plan
- [x] Verify file watching works in VSCode after modifications
- [x] Verify file watching works when files are created/deleted externally
- [ ] Test with another LSP-compliant editor if possible

Fixes #54