### PR TITLE
#35 Add grammar for `types` tag

### DIFF
--- a/packages/language-server/__tests__/completions/variableProperties.test.ts
+++ b/packages/language-server/__tests__/completions/variableProperties.test.ts
@@ -110,9 +110,25 @@ describe('variableProperties (PHP type resolution)', () => {
         );
     };
 
-    test('completes properties of a typed variable', async () => {
+    test('completes properties of a typed variable annotation', async () => {
         const completions = await runCompletion(
             `{# @var something \\App\\SomeClass #}
+            {{ something.$0 }}`,
+        );
+        assertExpectedType(completions, MockPhpExecutor.classMap['App\\SomeClass']);
+    });
+
+    test('completes properties of a types required variable declaration', async () => {
+        const completions = await runCompletion(
+            `{% types something: '\\App\\SomeClass' %}
+            {{ something.$0 }}`,
+        );
+        assertExpectedType(completions, MockPhpExecutor.classMap['App\\SomeClass']);
+    });
+
+    test('completes properties of a types optional variable declaration', async () => {
+        const completions = await runCompletion(
+            `{% types something?: '\\App\\SomeClass' %}
             {{ something.$0 }}`,
         );
         assertExpectedType(completions, MockPhpExecutor.classMap['App\\SomeClass']);

--- a/packages/language-server/src/staticCompletionInfo.ts
+++ b/packages/language-server/src/staticCompletionInfo.ts
@@ -810,6 +810,7 @@ export const twigKeywords: KeywordCompletionItem[] = [
     { label: 'import' },
     { label: 'include' },
     { label: 'sandbox' },
+    { label: 'types' },
     { label: 'use' },
     { label: 'verbatim' },
     { label: 'with' },

--- a/packages/language-server/src/symbols/LocalSymbolCollector.ts
+++ b/packages/language-server/src/symbols/LocalSymbolCollector.ts
@@ -94,6 +94,11 @@ export class LocalSymbolCollector {
                     continue;
                 }
 
+                case 'types': {
+                    await this.#visitTypes(cursor.currentNode);
+                    continue;
+                }
+
                 case 'macro': {
                     await this.#visitMacro(cursor.currentNode);
                     continue;
@@ -163,6 +168,19 @@ export class LocalSymbolCollector {
             symbols: scopedSymbolCollector.localSymbols,
         };
         this.localSymbols.macro.push(macroWithSymbols);
+    }
+
+    async #visitTypes(currentNode: SyntaxNode) {
+        const typesVariableNodes = currentNode.namedChildren;
+        for (const variable of typesVariableNodes) {
+            switch (variable.type) {
+                case 'types_optional_declaration':
+                case 'types_required_declaration': {
+                    this.#visitVariableDeclaration(variable);
+                    continue;
+                }
+            }
+        }
     }
 
     async #visitVariableDeclaration(currentNode: SyntaxNode) {

--- a/packages/language-server/src/typing/ExpressionTypeResolver.ts
+++ b/packages/language-server/src/typing/ExpressionTypeResolver.ts
@@ -11,12 +11,20 @@ export class ExpressionTypeResolver implements IExpressionTypeResolver {
     static supportedTypes = new Set([
         'call_expression',
         'member_expression',
+        'types_optional_declaration',
+        'types_required_declaration',
         'variable',
         'var_declaration',
         // TODO: handle these
         // 'subscript_expression',
         // 'filter_expression',
         // 'parenthesized_expression',
+    ]);
+
+    static variableDeclarationTypes = new Set([
+        'types_optional_declaration',
+        'types_required_declaration',
+        'var_declaration',
     ]);
 
     constructor(
@@ -67,7 +75,7 @@ export class ExpressionTypeResolver implements IExpressionTypeResolver {
             return variable.reflectedType;
         }
 
-        if (expr.type === 'var_declaration') {
+        if (ExpressionTypeResolver.variableDeclarationTypes.has(expr.type)) {
             const typeNode = expr.childForFieldName('type');
 
             if (!typeNode) return null;

--- a/packages/tree-sitter-twig/corpus/statements.txt
+++ b/packages/tree-sitter-twig/corpus/statements.txt
@@ -661,7 +661,9 @@ Types declaration
   (types
     (types_required_declaration
       (variable)
-      (string))))
+      (union_type
+        (primitive_type)
+        (primitive_type)))))
 
 ==================
 Types several declarations
@@ -675,27 +677,37 @@ Types several declarations
   (types
     (types_required_declaration
       (variable)
-      (string))
+      (union_type
+        (primitive_type)
+        (primitive_type)))
     (types_optional_declaration
       (variable)
-      (string))))
+      (primitive_type))))
 
 ==================
 Types enclosed with braces
 ==================
 {% types {
   foo: 'string|bool',
-  score?: 'int',
+  baz?: '\Iterator&\Countable',
 } %}
 ---
 (template
   (types
     (types_required_declaration
       (variable)
-      (string))
+      (union_type
+        (primitive_type)
+        (primitive_type)))
     (types_optional_declaration
       (variable)
-      (string))))
+      (intersection_type
+        (qualified_name
+          (namespace)
+          (php_identifier))
+        (qualified_name
+          (namespace)
+          (php_identifier))))))
 
 ==================
 Use

--- a/packages/tree-sitter-twig/corpus/statements.txt
+++ b/packages/tree-sitter-twig/corpus/statements.txt
@@ -651,6 +651,52 @@ Set block
       (output
         (variable))
       (content))))
+
+==================
+Types declaration
+==================
+{% types foo: 'string|bool' %}
+---
+(template
+  (types
+    (types_required_declaration
+      (variable)
+      (string))))
+
+==================
+Types several declarations
+==================
+{% types
+  foo: 'string|bool',
+  score?: 'int',
+%}
+---
+(template
+  (types
+    (types_required_declaration
+      (variable)
+      (string))
+    (types_optional_declaration
+      (variable)
+      (string))))
+
+==================
+Types enclosed with braces
+==================
+{% types {
+  foo: 'string|bool',
+  score?: 'int',
+} %}
+---
+(template
+  (types
+    (types_required_declaration
+      (variable)
+      (string))
+    (types_optional_declaration
+      (variable)
+      (string))))
+
 ==================
 Use
 ==================

--- a/packages/tree-sitter-twig/grammar.js
+++ b/packages/tree-sitter-twig/grammar.js
@@ -583,6 +583,34 @@ module.exports = grammar({
         alias('endsandbox', 'keyword'),
       ),
 
+    types: ($) =>
+      statement(
+        $,
+        alias('types', 'keyword'),
+        seq(
+          optional('{'),
+          commaSep1(
+            choice(
+              field('types_required_declaration', $.types_required_declaration),
+              field('types_optional_declaration', $.types_optional_declaration),
+            )
+          ),
+          optional('}'),
+        ),
+      ),
+
+    types_required_declaration: ($) => seq(
+        field('variable', alias($.identifier, $.variable)),
+        ':',
+        field('type', $.string),
+      ),
+
+    types_optional_declaration: ($) => seq(
+        field('variable', alias($.identifier, $.variable)),
+        '?:',
+        field('type', $.string),
+      ),
+
     use: ($) =>
       statement(
         $,
@@ -635,6 +663,7 @@ module.exports = grammar({
         $.sandbox,
         $.set,
         $.set_block,
+        $.types,
         $.use,
         $.verbatim,
         $.with,

--- a/packages/tree-sitter-twig/grammar.js
+++ b/packages/tree-sitter-twig/grammar.js
@@ -602,13 +602,13 @@ module.exports = grammar({
     types_required_declaration: ($) => seq(
         field('variable', alias($.identifier, $.variable)),
         ':',
-        field('type', $.string),
+        string(field('type', $._type)),
       ),
 
     types_optional_declaration: ($) => seq(
         field('variable', alias($.identifier, $.variable)),
         '?:',
-        field('type', $.string),
+        string(field('type', $._type)),
       ),
 
     use: ($) =>
@@ -706,6 +706,20 @@ function source_elements($, fieldName = 'body') {
  */
 function statement($, ...args) {
   return seq($._statement_start, ...args, $._statement_stop);
+}
+
+/**
+ * Creates a rule to match a single-quoted or double-quoted enclosed rule.
+ *
+ * @param {Rule} rule
+ *
+ * @return {ChoiceRule}
+ */
+function string(rule) {
+  return choice(
+    seq('"', rule, '"'),
+    seq("'", rule, "'"),
+  );
 }
 
 /**

--- a/packages/vscode/syntaxes/twig.tmLanguage.json
+++ b/packages/vscode/syntaxes/twig.tmLanguage.json
@@ -899,7 +899,7 @@
             "name": "meta.hash.twig"
         },
         "twig-keywords": {
-            "match": "(?<=\\s)((?:end)?(?:autoescape|block|embed|filter|for|if|macro|raw|sandbox|set|spaceless|trans|verbatim)|as|do|else|elseif|extends|flush|from|ignore missing|import|include|only|use|with)(?=\\s)",
+            "match": "(?<=\\s)((?:end)?(?:autoescape|block|embed|filter|for|if|macro|raw|sandbox|set|spaceless|trans|verbatim)|as|do|else|elseif|extends|flush|from|ignore missing|import|include|only|types|use|with)(?=\\s)",
             "name": "keyword.control.twig"
         },
         "twig-functions-warg": {


### PR DESCRIPTION
Resolves #35

<details>
<summary>Preface</summary>

* I use this language server via [LSP-twiggy](https://github.com/sublimelsp/LSP-twiggy) for Sublime Text.
* This is my first experience with language servers and tree-sitter.
* ~~At this time, I am trying to figure out how I can test these changes in Sublime Text.~~
* Guidance and suggestions are greatly welcome.

Initially, the purpose of this pull request is to resolve the "unexpected syntax" notice on optional variables:

<img width="350" height="92" alt="Screen capture of an unexpected syntax notice on an optional variable in a Twig types tag using twiggy-language-server v0.19.1" src="https://github.com/user-attachments/assets/ebb7acfe-2365-47b5-b45a-42237c032184" />

Snippet from the above screen capture:

```twig
{% types {
	debug?: 'boolean',
} %}
```

</details>

---

This pull request adds support, including type annotation, for the [`types` tag](https://twig.symfony.com/doc/3.x/tags/types.html).

The grammar consists of:

* `types` statement for the tag: `{% types … %}` and `{% types {…} %}`
	* `types_required_declaration`: `var: 'string'`
	* `types_optional_declaration`: `var?: 'string'`

Each `types_*_declaration` has two fields, `variable` and `type`, similar to `var_declaration`.