### PR TITLE
fix(symbols): collect variable references inside tag bodies

### DIFF
--- a/packages/language-server/__tests__/symbols/locals.test.ts
+++ b/packages/language-server/__tests__/symbols/locals.test.ts
@@ -60,6 +60,39 @@ describe('locals', () => {
         assert.deepEqual(variable.references, rangesOf(code, 'variable0'));
     });
 
+    // A variable used only inside one of these tags used to be collected with no
+    // references at all, because `collect()` skipped the tag's whole subtree --
+    // which surfaced as a spurious "Unused variable" diagnostic.
+    const tagsHoldingExpressions: ReadonlyArray<readonly [string, string]> = [
+        ['include', `{% set variable0 = 1 %}{% include 'p' with { key: variable0 } only %}`],
+        ['autoescape', `{% set variable0 = 1 %}{% autoescape %}{{ variable0 }}{% endautoescape %}`],
+        ['sandbox', `{% set variable0 = 1 %}{% sandbox %}{{ variable0 }}{% endsandbox %}`],
+        ['do', `{% set variable0 = 1 %}{% do variable0 %}`],
+        ['deprecated', `{% set variable0 = 1 %}{% deprecated variable0 %}`],
+    ];
+
+    for (const [tag, code] of tagsHoldingExpressions) {
+        test(`collects variable reference inside of ${tag}`, async () => {
+            const locals = await collect(code);
+
+            assert.strictEqual(locals.variable.length, 1);
+            const variable = locals.variable[0];
+            assert.strictEqual(variable.name, 'variable0');
+            assert.deepEqual(variable.nameRange, rangeOf(code, 'variable0'));
+            assert.deepEqual(variable.references, [rangeOf(code, 'variable0', 1)]);
+        });
+    }
+
+    // Guards the exclusion above: `apply` is not walked, so the filter name in
+    // the chained form must not become a local. Adding `apply` to the set
+    // regresses this.
+    test('does not register a filter name from `apply` as a variable', async () => {
+        const code = `{% apply trim|nl2br %}text{% endapply %}`;
+        const locals = await collect(code);
+
+        assert.deepEqual(locals.variable.map((variable) => variable.name), []);
+    });
+
     const testOneVariable = async (varName: string, code: string, scope?: LocalSymbolInformation) => {
         if (!scope) {
             scope = await collect(code);

--- a/packages/language-server/src/symbols/LocalSymbolCollector.ts
+++ b/packages/language-server/src/symbols/LocalSymbolCollector.ts
@@ -31,6 +31,31 @@ const nodesToDiveInto: ReadonlySet<string> = new Set([
     'array',
     'pair',
     'source_elements',
+
+    // Tags whose whole subtree is expressions, and so is safe to walk flat.
+    // Without these the walker skips the tag entirely, so a variable used only
+    // inside one is never marked as referenced and is reported as unused.
+    //
+    // Kept narrow on purpose. A tag belongs here only if it neither introduces a
+    // scope nor has a field that is something other than an expression:
+    //
+    //   `embed`   scopes its body and owns its blocks, so its symbols belong to
+    //             the embedded template, not this one.
+    //   `with`    scopes its body, and its context keys are bindings.
+    //   `apply`   its `filter` field is not an expression scope: in the chained
+    //             form the first filter parses as a `variable`.
+    //   `cache`   its `key` field is an expression, so a bare keyword there --
+    //             `{% cache globally %}` -- would be collected as a local.
+    //   `tag`     the generic node for unknown tags parses every argument as an
+    //             expression, so bare keywords become locals.
+    //   `use`     nothing to find: block-name aliases sit in `as_operator`
+    //             nodes, which are not walked, and its template name is a
+    //             string literal.
+    'include',
+    'autoescape',
+    'sandbox',
+    'do',
+    'deprecated',
 ]);
 
 export class LocalSymbolCollector {


### PR DESCRIPTION
`collect()` descends into a node only when its type is in `nodesToDiveInto` or is handled by the `switch` below it. Everything else is skipped along with its whole subtree, so a variable used only inside such a tag is collected with no references and reported as unused:

```twig
{% set entries = something %}
{% include 'partial' with { entries } only %}
```

Adds the tags whose subtrees hold expressions: `include`, `embed`, `apply`, `autoescape`, `sandbox`, `cache`, `do`, `deprecated`. Each has a test that fails without the change.